### PR TITLE
Implement SEO and accessibility tweaks

### DIFF
--- a/app/(root)/contact/page.tsx
+++ b/app/(root)/contact/page.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
 import Contact  from '@/components/contact/Contact'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Contact - Jeunesse de Porsel',
+  description: 'Formulaire de contact de la Jeunesse de Porsel.',
+}
 
 const page = () => {
   return (

--- a/app/(root)/fondue/page.tsx
+++ b/app/(root)/fondue/page.tsx
@@ -2,6 +2,12 @@ import Fondue from '@/components/fondue/Fondue'
 import FondueEvenementDisplayer from '@/components/fondue/FondueEvenementDisplayer'
 import FondueInfoPratique from '@/components/fondue/FondueInfoPratique'
 import React  from 'react'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Fondue - Jeunesse de Porsel',
+  description: 'Informations sur la traditionnelle fondue de la société.',
+}
 
 const page = async () => {
 

--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -8,10 +8,11 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <main className="flex h-screen">
       <section className="flex size-full flex-1 flex-col">
+        <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 bg-white text-black p-2">Aller au contenu principal</a>
         <MobileNavigation />
         <Header />
 
-        <div className="main-content">
+        <div id="main-content" className="main-content">
           {children}
           <Footer />
         </div>

--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -1,5 +1,11 @@
 import AccueilTheatre from "@/components/accueil/AccueilTheatre";
 import AccueilJeunesse from "@/components/accueil/AccueilJeunesse";
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Accueil - Jeunesse de Porsel',
+  description: 'Bienvenue sur le site officiel de la Jeunesse de Porsel.',
+}
 
 const Home = () => {
   return (

--- a/app/(root)/societe/page.tsx
+++ b/app/(root)/societe/page.tsx
@@ -2,6 +2,12 @@ import React from 'react'
 import AccueilJeunesse from '@/components/accueil/AccueilJeunesse'
 import SocieteComite from '@/components/societe/SocieteComite'
 import SocieteMembre from '@/components/societe/SocieteMembre'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Société - Jeunesse de Porsel',
+  description: 'Présentation de la société et de son comité.',
+}
 
 const page = () => {
   return (

--- a/app/(root)/theatre/page.tsx
+++ b/app/(root)/theatre/page.tsx
@@ -3,6 +3,12 @@ import TheatreInfoPratique from "@/components/theatre/TheatreInfoPratique";
 import TheatrePresentationActeur from "@/components/theatre/TheatrePresentationActeur";
 import TheatreSynopsys from "@/components/theatre/TheatreSynopsys";
 import TheatreReservation from "@/components/theatre/TheatreReservation";
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Théâtre - Jeunesse de Porsel',
+  description: 'Informations sur les représentations théâtrales.',
+}
 const Home = () =>{
   return(
     <>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,31 @@
 import type { Metadata } from "next";
 import { Poppins } from "next/font/google";
 import "./globals.css";
-import { Analytics } from "@vercel/analytics/react"
+import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from '@vercel/speed-insights/next';
+import CookieConsent from "@/components/layout/CookieConsent";
 
 const poppins = Poppins({
   subsets: ["latin"],
-  weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+  weight: ["400", "700"],
   variable: "--font-poppins",
 });
 
 export const metadata: Metadata = {
   title: "Jeunesse de Porsel",
   description: "Site officiel de la jeunesse de Porsel !",
+  metadataBase: new URL("https://jeunessedeporsel.ch"),
+  openGraph: {
+    title: "Jeunesse de Porsel",
+    description: "Site officiel de la jeunesse de Porsel !",
+    url: "https://jeunessedeporsel.ch/",
+    siteName: "Jeunesse de Porsel",
+    type: "website",
+  },
+  viewport: {
+    width: "device-width",
+    initialScale: 1,
+  },
 };
 
 export default function RootLayout({
@@ -24,6 +37,7 @@ export default function RootLayout({
     <html lang="fr">
       <body className={`${poppins.variable} font-poppins antialiased`} >
         {children}
+        <CookieConsent />
         <Analytics/>
         <SpeedInsights />
 

--- a/components/CarouselImages.tsx
+++ b/components/CarouselImages.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/carousel";
 
 import Image from "next/image";
+import { Search } from "lucide-react";
 
 const CarouselImages = ({ imageCarousel }: ImageTypeData) => {
   const plugin = React.useRef(
@@ -31,12 +32,7 @@ const CarouselImages = ({ imageCarousel }: ImageTypeData) => {
           {imageCarousel.map(({ alt, src }: { alt: string; src: string }) => (
             <CarouselItem key={alt} className="flex justify-center">
               <div onClick={() => openZoomedImage(src)} className="bg-jeunesse absolute flex size-full items-center justify-center  bg-opacity-55 opacity-0 transition-all hover:opacity-100">
-                <Image
-                  src="https://img.icons8.com/?size=100&id=34825&format=png&color=ffffff"
-                  alt="zoom"
-                  width="50"
-                  height="50"
-                />
+                <Search className="size-8 text-white" aria-hidden="true" />
               </div>
               <Image
                 src={src}

--- a/components/accueil/AccueilJeunesse.tsx
+++ b/components/accueil/AccueilJeunesse.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
+import { ChevronsDown } from "lucide-react";
 const JeunesseSection = ({href}:{href:string}) => {
   return (
     <section className="section-jeunesse h-full">
@@ -8,12 +9,13 @@ const JeunesseSection = ({href}:{href:string}) => {
         <div className="flex h-full flex-col items-center justify-center text-jeunesse-white">
           <div className="bg-jeunesse absolute size-full bg-opacity-85"></div>
           <div className="text-center text-jeunesse-white z-10 flex flex-col items-center justify-center gap-4 animate-in fade-in zoom-in">
-            <h1 className="h1">Jeunessse de Porsel</h1>
+            <h1 className="h1">Jeunesse de Porsel</h1>
             <h2 className="h2">Notre équipe de copains !</h2>
           </div>
           <div className="z-10 bottom-10 absolute flex flex-col items-center justify-center">
-          <Link className="transition-bigger flex flex-col justify-items-center items-center gap-2 text-light-200 hover:text-jeunesse-white"  href={href}>Découvrez notre société
-          <Image src='https://img.icons8.com/?size=100&id=2760&format=png&color=A3B2C7' alt="scroll down" width={'25'} height={'25'}/>
+          <Link className="transition-bigger flex flex-col items-center gap-2 text-light-200 hover:text-jeunesse-white"  href={href}>
+          Découvrez notre société
+          <ChevronsDown className="size-6" aria-hidden="true" />
           </Link>
           </div>
         </div>

--- a/components/layout/CookieConsent.tsx
+++ b/components/layout/CookieConsent.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useEffect, useState } from "react";
+
+const CookieConsent = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const saved = typeof window !== "undefined" && localStorage.getItem("cookie-consent");
+    if (!saved) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("cookie-consent", "true");
+    }
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 flex flex-col items-center gap-2 bg-jeunesse-white p-4 text-black">
+      <p>Ce site utilise des cookies pour améliorer votre expérience.</p>
+      <button onClick={accept} className="rounded bg-brand px-4 py-2 text-white">
+        Accepter
+      </button>
+    </div>
+  );
+};
+
+export default CookieConsent;

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import React from "react";
+import { Instagram, Facebook } from "lucide-react";
 
 const Footer = () => {
   return (
@@ -19,24 +20,15 @@ const Footer = () => {
             href="https://www.instagram.com/jeunesse_porsel?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw=="
             target="_blank"
             className="transition-bigger"
+            aria-label="Instagram"
           >
-            <Image
-              src="https://img.icons8.com/?size=100&id=Xy10Jcu1L2Su&format=png&color=000000"
-              alt="instagram"
-              width={50}
-              height={50}
-            />
+            <Instagram className="size-8" aria-hidden="true" />
           </Link>
           <Link
             href="https://www.facebook.com/p/Jeunesse-Porsel-100043547756872/?locale=fr_FR"
             className="transition-bigger" target="_blank"
           >
-            <Image
-              src="https://img.icons8.com/?size=100&id=uLWV5A9vXIPu&format=png&color=000000"
-              alt="facebook"
-              width={50}
-              height={50}
-            />
+            <Facebook className="size-8" aria-hidden="true" />
           </Link>
         </div>
       </div>

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,14 +7,7 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
-  images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "img.icons8.com",
-      },
-    ],
-  },
+  images: {},
 };
 
 export default nextConfig;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://jeunessedeporsel.ch/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://jeunessedeporsel.ch/</loc>
+  </url>
+  <url>
+    <loc>https://jeunessedeporsel.ch/theatre</loc>
+  </url>
+  <url>
+    <loc>https://jeunessedeporsel.ch/fondue</loc>
+  </url>
+  <url>
+    <loc>https://jeunessedeporsel.ch/societe</loc>
+  </url>
+  <url>
+    <loc>https://jeunessedeporsel.ch/contact</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add static robots.txt and sitemap
- correct heading typo and replace external icons with lucide icons
- add cookie consent banner
- create skip link for accessibility
- add per-page metadata and Open Graph tags

## Testing
- `npm run lint` *(fails: Unknown options)*
- `npm run build` *(fails: network access needed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685bc67490ec832cbc7cc8a9f13bb977